### PR TITLE
ci: add GitHub Action

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           node-version: '12'
       - run: npm install
-      - run: npm run build
+      - run: CI=false npm run build


### PR DESCRIPTION
This PR adds GitHub Actions integration.

The CI script will try build the application. The building status will be shown on each pull request.

It is recommended to configure the repository after this PR has been merged. In settings, add branch protection rule for master. For every PR, ensure that `yarn` must pass before merging.

btw: free user has a quota of 2000 hours in GitHub Action per month in private repo. This limit should be enough for this project.